### PR TITLE
change copyrights of all pages and navbar icon size reduce

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,7 +34,7 @@
 
         <a class="navbar-brand" href="index.html">
           <span class="logo-image">
-            <img src="images/iconn.png" class="img-fluid">
+            <img id="medic-donation-icon" src="images/iconn.png" class="img-fluid">
           </span>Medic Donation
         </a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav" aria-controls="ftco-nav" aria-expanded="false" aria-label="Toggle navigation">
@@ -291,10 +291,7 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-center">
-
-            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | This template is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com" target="_blank">zero-one</a>
-  <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></p>
+            <p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
           </div>
         </div>
       </div>

--- a/contact.html
+++ b/contact.html
@@ -33,7 +33,7 @@
   
         <a class="navbar-brand" href="index.html">
           <span class="logo-image">
-            <img src="images/iconn.png" class="img-fluid">
+            <img id="medic-donation-icon" src="images/iconn.png" class="img-fluid">
           </span>Medic Donation
         </a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav" aria-controls="ftco-nav" aria-expanded="false" aria-label="Toggle navigation">
@@ -163,10 +163,7 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-center">
-
-            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | This template is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="#" target="_blank">zero-one</a>
-  <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></p>
+            <p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
           </div>
         </div>
       </div>

--- a/css/style.css
+++ b/css/style.css
@@ -9105,7 +9105,7 @@ textarea.form-control {
 
 .ftco-footer {
   font-size: 16px;
-  padding: 7em 0;
+  padding: 3em 0;
   background: #252525;
 }
 .ftco-footer .ftco-footer-logo {
@@ -10062,6 +10062,11 @@ textarea.form-control {
   -webkit-animation: loader-dash 1.5s ease-in-out infinite;
           animation: loader-dash 1.5s ease-in-out infinite;
   stroke-linecap: round;
+}
+
+#medic-donation-icon {
+  width: 100px;
+  height: 100px;
 }
 
 @-webkit-keyframes loader-rotate {

--- a/donate.html
+++ b/donate.html
@@ -248,11 +248,8 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-center">
-
-            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | This template is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com" target="_blank">Colorlib</a>
-  <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></p>
-          </div>
+			<p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
+ 		  </div>
         </div>
       </div>
     </footer>

--- a/forgetpass.html
+++ b/forgetpass.html
@@ -146,10 +146,7 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-center">
-
-            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | This template is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com" target="_blank">Colorlib</a>
-  <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></p>
+            <p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
 
 			<a class="navbar-brand" href="index.html">
 				<span class="logo-image">
-					<img src="images/iconn.png" class="img-fluid">
+					<img id="medic-donation-icon" src="images/iconn.png" class="img-fluid">
 				</span>Medic Donation
 			</a>
 			<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav"
@@ -477,15 +477,7 @@
 			</div>
 			<div class="row">
 				<div class="col-md-12 text-center">
-
-					<p>
-						<!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-						Copyright &copy;
-						<script>document.write(new Date().getFullYear());</script> All rights reserved | This template
-						is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com"
-							target="_blank">zero-one</a>
-						<!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-					</p>
+					<p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
 				</div>
 			</div>
 		</div>

--- a/signin.html
+++ b/signin.html
@@ -155,10 +155,7 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-center">
-
-            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | This template is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com" target="_blank">Colorlib</a>
-  <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></p>
+            <p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
           </div>
         </div>
       </div>

--- a/volunteer.html
+++ b/volunteer.html
@@ -206,10 +206,7 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-center">
-
-            <p><!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. -->
-  Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | This template is made with <i class="icon-heart" aria-hidden="true"></i> by <a href="https://colorlib.com" target="_blank">Colorlib</a>
-  <!-- Link back to Colorlib can't be removed. Template is licensed under CC BY 3.0. --></p>
+            <p>Copyright &copy;<script>document.write(new Date().getFullYear());</script> All rights reserved | Made with <i class="icon-heart" aria-hidden="true"></i> by Contributors</a></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
I have made all the pages copyrights tag to a similar one . Also found the icon in the navbar of all pages too big to read the content. Reduced the size of icon so people could actually get to see more content on window screen.